### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ To put it in ~/.local/bin/ so you are able to run it from the terminal
 Run 
 ```
 sudo codesign --force --sign - --preserve-metadata=entitlements ~/.local/bin/claude-notelemetry
-sudo codesign --force --sign - --preserve-metadata=entitlements ~/.local/bin/claude-notelemetry
 ```
 To bypass code signing restrictions in MacOS 26. Will need to be done after every patch.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ To put it in ~/.local/bin/ so you are able to run it from the terminal
 
 Run 
 ```
-sudo codesign --force --sign - --preserve-metadata=entitlements ~/.local/bin/claude-private
+sudo codesign --force --sign - --preserve-metadata=entitlements ~/.local/bin/claude-notelemetry
 sudo codesign --force --sign - --preserve-metadata=entitlements ~/.local/bin/claude-notelemetry
 ```
 To bypass code signing restrictions in MacOS 26. Will need to be done after every patch.


### PR DESCRIPTION
Correcting a typo, changed "private" to "notelemetry" to match the default name.